### PR TITLE
fixes issue with non-order mailers

### DIFF
--- a/app/mailers/spree/base_mailer_decorator.rb
+++ b/app/mailers/spree/base_mailer_decorator.rb
@@ -1,6 +1,6 @@
 module AddAllRecipients
-  def mail(headers={}, &block)
-    headers[:to] = all_recipients
+  def mail(headers = {}, &block)
+    headers[:to] = all_recipients if all_recipients.present?
     super
   end
 end
@@ -9,6 +9,7 @@ Spree::BaseMailer.class_eval do
   prepend AddAllRecipients
 
   private
+
   # this method will be implemented in each mailer_decorator
   # retrieving order.all_recipients from the mailer context object
   def all_recipients

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -66,4 +66,18 @@ describe Spree::OrderMailer, :type => :mailer do
       expect(ActionMailer::Base.deliveries.first.to).to eq([order.email])
     end
   end
+
+  context "when all_recipients is blank" do
+    before do
+      allow(order).to receive(:all_recipients).and_return("")
+    end
+
+    it "sends confirm email just to customer email" do
+      message = Spree::OrderMailer.confirm_email(order)
+      message.deliver_now
+      expect(message.to).to eq([order.email])
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+      expect(ActionMailer::Base.deliveries.first.to).to eq([order.email])
+    end
+  end
 end


### PR DESCRIPTION
If this extension is used in an application that uses `Spree::BaseMailer` for non-order emails `headers[:to]` will be empty which will end up with:

```
ArgumentError: An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.
```

This PR should fix this.
